### PR TITLE
simple typo fix on rocketchat docker-compose

### DIFF
--- a/rocketchat/README.md
+++ b/rocketchat/README.md
@@ -37,7 +37,7 @@ services:
   rocketchat:
     image: rocketchat/rocket.chat:latest
     container_name: rocketchat
-#   port:
+#   ports:
 #       - 3000:3000
     command: >
       bash -c


### PR DESCRIPTION
hi... just found a small typo problem that breaks the docker-compose up if changing rocket-chat port